### PR TITLE
set context merge policy according to

### DIFF
--- a/daikiri/lib/Daikiri.m
+++ b/daikiri/lib/Daikiri.m
@@ -265,6 +265,7 @@
 
 +(NSManagedObjectContext*)managedObjectContext{
     NSManagedObjectContext * context = [DaikiriCoreData manager].managedObjectContext;
+    [context setMergePolicy:NSMergeByPropertyObjectTrumpMergePolicy];
     return context;
 }
 


### PR DESCRIPTION
https://stackoverflow.com/questions/4625232/failed-to-save-to-data-store-the-operation-couldn-t-be-completed-cocoa-error
Looks like that changing merge policy to overwrite helps in my case. More details developer.apple.com/library/ios/#documentation/cocoa/Reference/…,
https://stackoverflow.com/questions/8134562/which-nsmergepolicy-do-i-use